### PR TITLE
Move js-module tag inside platform

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,13 +9,13 @@
     <keywords>cordova,plugin,android,fingerprint,authentication</keywords>
     <repo></repo>
     <issue></issue>
-
-    <js-module src="www/FingerprintAuth.js" name="FingerprintAuth">
-        <clobbers target="FingerprintAuth" />
-    </js-module>
-
+        
     <!-- android -->
     <platform name="android">
+        <js-module src="www/FingerprintAuth.js" name="FingerprintAuth">
+            <clobbers target="FingerprintAuth" />
+        </js-module>
+        
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FingerprintAuth" >
                 <param name="android-package" value="com.cordova.plugin.android.fingerprintauth.FingerprintAuth"/>


### PR DESCRIPTION
This way error on runtime because not found plugin is avoided

Fix #1 